### PR TITLE
Change phrasing and styling, fix bugs

### DIFF
--- a/app/controllers/predictions_controller.rb
+++ b/app/controllers/predictions_controller.rb
@@ -96,10 +96,10 @@ class PredictionsController < ApplicationController
 
   def happenstance
     @title = "Recent Happenstance"
-    @unjudged = Prediction.unjudged.limit(3)
-    @judged = Prediction.judged.limit(3)
-    @recent = Prediction.recent.limit(3)
-    @responses = Response.recent.limit(6)
+    @unjudged = Prediction.unjudged.limit(5)
+    @judged = Prediction.judged.limit(5)
+    @recent = Prediction.recent.limit(5)
+    @responses = Response.recent.limit(25)
   end
   
   def judge

--- a/app/controllers/predictions_controller.rb
+++ b/app/controllers/predictions_controller.rb
@@ -39,7 +39,7 @@ class PredictionsController < ApplicationController
   
   def home
     @prediction = Prediction.new(:creator => current_user)
-    @responses = Response.recent.limit(10)
+    @responses = Response.recent.limit(25)
     @title = "How sure are you?"
     @filter = 'popular'
     @predictions = Prediction.popular.limit(5)

--- a/app/helpers/datetime_description_helper.rb
+++ b/app/helpers/datetime_description_helper.rb
@@ -1,12 +1,15 @@
 module DatetimeDescriptionHelper
   def time_in_words_with_context(time)
     time_str = time_ago_in_words(time)
-    if time <= Time.now
+    if time_str.include? "month" or time_str.include? "year"
+      # If it's been over a month, return the full date
+      "on #{time.strftime("%Y-%m-%d")}"
+    elsif time <= Time.now
       "#{time_str} ago"
     else
       "in #{time_str}"
     end
   rescue RangeError,NoMethodError # known issue in Rails
-    "in ages"
+    "on #{time.strftime("%Y-%m-%d")}"
   end
 end

--- a/app/helpers/labelled_form_builder.rb
+++ b/app/helpers/labelled_form_builder.rb
@@ -40,7 +40,7 @@ class LabelledFormBuilder < ActionView::Helpers::FormBuilder
 
   def confidence_field(method, options={})
     new_class = "#{options.delete(:class)} confidence".strip
-    new_options = {:trailing_content => ' %',:maxlength => 3, :class => new_class}
+    new_options = {:trailing_content => ' % chance',:maxlength => 3, :class => new_class}
     text_field(method, new_options.merge(options))
   end
   

--- a/app/helpers/markup_helper.rb
+++ b/app/helpers/markup_helper.rb
@@ -1,4 +1,24 @@
 module MarkupHelper
+  # A copy of the private AUTO_LINK_RE from ActionView::Helpers::TextHelper,
+  # slightly simplified.
+  SIMPLER_AUTO_LINK_RE = %r{
+    (                          # leading text
+      <\w+.*?>|                # leading HTML tag, or
+      [^=!:'"/]|               # leading punctuation, or
+      ^                        # beginning of line
+    )
+    (
+      https?://
+      [-\w]+                   # subdomain or domain
+      (?:\.[-\w]+)*            # remaining subdomains or domain
+      (?::\d+)?                # port
+      (?:/(?:(?:[~\w\+@%=\(\)-]|(?:[,.;:][^\s$]))+)?)* # path
+      (?:\?[\w\+@%&=.;-]+)?    # query string
+      (?:\#[\w\-]*)?           # trailing anchor
+    )
+    ([[:punct:]]|<|$|)       # trailing text
+   }x
+
   def show_user(user, cls=nil)
     link_to h(user), user_path(user), :class => classes('user',cls)
   end
@@ -14,9 +34,20 @@ module MarkupHelper
   def confidence_and_count(prediction)
     "#{prediction.wager_count} with #{prediction.mean_confidence}%"
   end
-  
+
+  def linkify_for_redcloth(text)
+    text.gsub(SIMPLER_AUTO_LINK_RE) do
+      all, leading, url, trailing = $&, $1, $2, $3
+      %(#{leading}"#{url}":#{url}#{trailing})
+      # The above is slightly wrong because *bold* and _italic_ in
+      # "{url}:" portion (the link text, equivalent to the target)
+      # will be made bold/italic by RedCloth.  But that's slightly tricky to
+      # fix, and the URL points to the correct target anyway.
+    end
+  end
+
   def markup(text)
-    auto_link_urls(CleanCloth.new(text).to_html)
+    CleanCloth.new(linkify_for_redcloth(text)).to_html
   end
   
   def classes(*args)

--- a/app/helpers/markup_helper.rb
+++ b/app/helpers/markup_helper.rb
@@ -41,4 +41,9 @@ module MarkupHelper
       end
     end
   end
+
+  def style_for_confidence(confidence)
+    # http://www.w3.org/TR/css3-color/#hsl-examples
+    "background-color: hsl(#{(confidence * (200/100.0) - 70)}, 100%, 90%);"
+  end
 end

--- a/app/helpers/response_helper.rb
+++ b/app/helpers/response_helper.rb
@@ -1,12 +1,7 @@
 module ResponseHelper
   def confidence_for(wager)
     unless wager.confidence.blank?
-      if wager.confidence == 50
-        'is fence sitting'
-      else
-        against = wager.agree? ? "" : ' against'
-        "estimated #{wager.relative_confidence}%" + against
-      end
+      "estimated #{wager.confidence}%"
     end
   end
 

--- a/app/helpers/response_helper.rb
+++ b/app/helpers/response_helper.rb
@@ -1,7 +1,8 @@
 module ResponseHelper
   def confidence_for(wager)
     unless wager.confidence.blank?
-      "estimated #{wager.confidence}%"
+      "estimated #{content_tag(:span, "#{wager.confidence}%",
+        :class => "confidence", :style => style_for_confidence(wager.confidence))}"
     end
   end
 

--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -27,7 +27,7 @@ class Prediction < ActiveRecord::Base
     opts = {
       :include => :responses, # Eager loading of :judgements breaks judgement and unknown?
       :conditions => [
-        'predictions.deadline > UTC_TIMESTAMP() AND predictions.created_at > ?', 1.month.ago
+        'predictions.deadline > UTC_TIMESTAMP() AND predictions.created_at > ?', 2.weeks.ago
       ],
       :order => 'count(responses.prediction_id) DESC, predictions.deadline ASC',
       :group => 'predictions.id',

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -77,15 +77,11 @@
       <%# <li><a href="#">Education Centre</a></li>
       <li><a href="#">Links</a></li> %>
 		</ul>
-    <%# <ul class="right-links">
-      <li><a href="#">About</a></li>
-      <li><a href="#">Advertising</a></li>
-      <li><a href="#">Terms</a></li>
-      <li><a href="#">Privacy</a></li>
-      <li><a href="#">Help</a></li>
-    </ul>
-    %>
+	<ul class="right-links">
 		<span class="copyright">PredictionBook © 2008-2011</span>
+	</ul>
+
+
 	</div><!-- #footer -->
 
 </div><!-- #container -->

--- a/app/views/predictions/_form.html.erb
+++ b/app/views/predictions/_form.html.erb
@@ -27,9 +27,9 @@
 <div class="clear">
   <h2>Make a Prediction</h2>
 	<%= f.hidden_field :uuid %>
-  <%= f.text_area :description, :label => 'What do you think will happen?' %>
-  <%= f.confidence_field :initial_confidence, :label => 'How sure are you?' %>
-  <%= f.text_field :deadline_text, :label => 'When you will know?', :trailing_content => link_to('Help', '#date-help', :class => 'help facebox'), :preview => true %>
+  <%= f.text_area :description, :label => 'What do you think will (or won\'t) happen?' %>
+  <%= f.confidence_field :initial_confidence, :label => 'What\'s your estimate of this happening?' %>
+  <%= f.text_field :deadline_text, :label => 'When will you know?', :trailing_content => link_to('Help', '#date-help', :class => 'help facebox'), :preview => true %>
   <%= f.submit 'Lock it in!' %>
   <%= f.check_box :notify_creator, :label => 'Email me when I should know the outcome' %>
   <%- unless current_user.has_email? -%>

--- a/app/views/predictions/happenstance.html.erb
+++ b/app/views/predictions/happenstance.html.erb
@@ -19,6 +19,8 @@
 <p class='links'><%= link_to 'Show All', judged_predictions_url %></p>
 
 <h2>Recent Responses</h2>
+<div id="responses">
 <ul>
 <%= render :partial => @responses %>
 </ul>
+</div>

--- a/app/views/predictions/show.html.erb
+++ b/app/views/predictions/show.html.erb
@@ -15,10 +15,23 @@
   This prediction is <strong>private</strong>. <%= render :partial => 'predictions/private_note' %>
 </p>
 <%- end -%>
+<%= render :partial => 'predictions/events' %>
+<% if logged_in? -%>
+<div id='response'>
+  <%= render :partial => 'responses/form' %>
+</div>
+<div id='notification'>
+<h2>Email Notifications</h2>
+<div id="deadline_notification"><%= render :partial => @deadline_notification %></div>
+<div id="response_notification"><%= render :partial => @response_notification %></div>
+</div>
+<% else -%>
+<p><span class='notice'>Please <%= link_to 'log in', login_path %> to respond to or judge prediction</span></p>
+<% end -%>
 <% if logged_in? && !@prediction.withdrawn? -%>
 <div id="judgement">
   <h2>Judge this prediction</h2>
-  <p class="note">Only judge this prediction once its outcome is known.<br />Record your opinion below.</p>
+  <p class="note">Only judge this prediction once its outcome is known.<br />Record your opinion above, <strong>not</strong> here!</p>
   <% form_tag(judge_prediction_path(@prediction)) do %>
     <%=  outcome_button 'Unknown' %>
     <%=  outcome_button 'Right' %>
@@ -38,16 +51,3 @@
   <br />
 </div>
 <% end %>
-<%= render :partial => 'predictions/events' %>
-<% if logged_in? -%>
-<div id='response'>
-  <%= render :partial => 'responses/form' %>
-</div>
-<div id='notification'>
-<h2>Email Notifications</h2>
-<div id="deadline_notification"><%= render :partial => @deadline_notification %></div>
-<div id="response_notification"><%= render :partial => @response_notification %></div>
-</div>
-<% else -%>
-<p><span class='notice'>Please <%= link_to 'log in', login_path %> to respond to or judge prediction</span></p>
-<% end -%>

--- a/app/views/predictions/show.html.erb
+++ b/app/views/predictions/show.html.erb
@@ -31,7 +31,7 @@
       or if it would not be possible to decide its outcome.
     </p>
     <% form_for([:withdraw, @prediction], :html => {:method => :post}) do |f| %>
-      <%= f.submit 'Withdraw Prediction', :confirm => 'Are you sure you want to withdraw this prediction' %>
+      <%= f.submit 'Withdraw Prediction', :confirm => 'Are you sure you want to withdraw this prediction?' %>
     <% end %>
   </div>
   <% end %>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -1,4 +1,4 @@
-<h2>Add your estimate or comment</h2>
+<h2><strong>Add your estimate or comment</strong></h2>
 <% form_for([@prediction,@prediction_response]) do |f| %>
   <% if @prediction.open? %>
   <%= f.confidence_field(:confidence, :label => 'What\'s your estimate of this happening?') %>

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -1,7 +1,7 @@
-<h2>Join this prediction</h2>
+<h2>Add your estimate or comment</h2>
 <% form_for([@prediction,@prediction_response]) do |f| %>
   <% if @prediction.open? %>
-  <%= f.confidence_field(:confidence, :label => 'How sure are you?') %>
+  <%= f.confidence_field(:confidence, :label => 'What\'s your estimate of this happening?') %>
     <% unless @prediction.count_wagers_by(current_user).zero? %>
     <p class="note">
       You can put another wager on this prediction, you may want to do this if

--- a/app/views/responses/_form.html.erb
+++ b/app/views/responses/_form.html.erb
@@ -4,7 +4,7 @@
   <%= f.confidence_field(:confidence, :label => 'What\'s your estimate of this happening?') %>
     <% unless @prediction.count_wagers_by(current_user).zero? %>
     <p class="note">
-      You can put another wager on this prediction, you may want to do this if
+      You can put another wager on this prediction; you may want to do this if
       you have revised an estimate or have had a change of opinion.
       Older wagers are still kept as they are a record of how you felt at the time.
     </p>

--- a/app/views/responses/_wager.xhtml.erb
+++ b/app/views/responses/_wager.xhtml.erb
@@ -1,6 +1,7 @@
 <%= show_user(wager.user) %>
 estimated
-<%= wager.confidence %>%
+<%= content_tag :span, "#{wager.confidence}%", :class => "confidence",
+  :style => style_for_confidence(wager.confidence) %>
 on
 <%= content_tag :span, 
    link_to(show_title(wager.prediction.description), wager.prediction),

--- a/app/views/responses/_wager.xhtml.erb
+++ b/app/views/responses/_wager.xhtml.erb
@@ -1,21 +1,19 @@
 <%= show_user(wager.user) %>
-<%= ((Time.current > wager.prediction.deadline) || !wager.prediction.unknown?) ? 'was' : 'is' %>
-<%= wager.relative_confidence %>%
-<%= wager.agree? ? 'sure' : 'against' %>
+estimated
+<%= wager.confidence %>%
+on
 <%= content_tag :span, 
    link_to(show_title(wager.prediction.description), wager.prediction),
    :class => (wager.prediction.withdrawn? ? 'withdrawn' : nil) -%>
 <%=  %>
-<%= show_time(wager.prediction.deadline) %>;
-<% if wager.prediction.open? %>
-<%   if Time.current > wager.prediction.deadline %>
-so <%= link_to 'judge them!', wager.prediction %>
-<%   else %>
-<%= link_to 'how sure are you?', wager.prediction %>
+<%= show_time(wager.prediction.deadline) -%>
+<% if wager.prediction.open? -%>
+<%   if Time.current > wager.prediction.deadline -%>
+, so <%= link_to 'judge them!', wager.prediction %>
 <%   end -%>
-<% elsif !wager.unknown?; outcome = wager.correct? ? 'correct' : 'wrong' -%>
+<% elsif !wager.unknown?; outcome = wager.correct? ? 'correct' : 'wrong' %>
 and was
 <%= content_tag :span, outcome, :class => "outcome #{outcome}" -%>
-<% else -%>
+<% else %>
 but withdrew the prediction <%= show_time(wager.prediction.updated_at)-%> 
 <% end -%>

--- a/app/views/responses/_wager.xhtml.erb
+++ b/app/views/responses/_wager.xhtml.erb
@@ -5,7 +5,7 @@ estimated
 on
 <%= content_tag :span, 
    link_to(show_title(wager.prediction.description), wager.prediction),
-   :class => (wager.prediction.withdrawn? ? 'withdrawn' : nil) -%>
+   :class => (wager.prediction.withdrawn? ? 'withdrawn ' : '') + "break-word" -%>
 <%=  %>
 <abbr title="To be decided (judged)">TBD</abbr>
 <%= show_time(wager.prediction.deadline) -%>

--- a/app/views/responses/_wager.xhtml.erb
+++ b/app/views/responses/_wager.xhtml.erb
@@ -7,6 +7,7 @@ on
    link_to(show_title(wager.prediction.description), wager.prediction),
    :class => (wager.prediction.withdrawn? ? 'withdrawn' : nil) -%>
 <%=  %>
+<abbr title="To be decided (judged)">TBD</abbr>
 <%= show_time(wager.prediction.deadline) -%>
 <% if wager.prediction.open? -%>
 <%   if Time.current > wager.prediction.deadline -%>

--- a/public/403.html
+++ b/public/403.html
@@ -4,7 +4,6 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>The page you were looking for is forbidden (403)</title>
-	<link rel="stylesheet" type="text/css" href="/stylesheets/pbook.css">
 </head>
 
 <body>

--- a/public/404.html
+++ b/public/404.html
@@ -4,14 +4,13 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>The page you were looking for doesn't exist (404)</title>
-	<link rel="stylesheet" type="text/css" href="/stylesheets/pbook.css">
 </head>
 
 <body>
   <!-- This file lives in public/404.html -->
   <div class="dialog">
     <h1>The page you were looking for doesn't exist.</h1>
-    <p>You may have mistyped the address or the page may have moved.</p>
+    <p><a href="/">PredictionBook home</a></p>
   </div>
 </body>
 </html>

--- a/public/422.html
+++ b/public/422.html
@@ -4,7 +4,6 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>The change you wanted was rejected (422)</title>
-	<link rel="stylesheet" type="text/css" href="/stylesheets/pbook.css">
 </head>
 
 <body>

--- a/public/500.html
+++ b/public/500.html
@@ -4,7 +4,6 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>We're sorry, but something went wrong (500)</title>
-	<link rel="stylesheet" type="text/css" href="/stylesheets/pbook.css">
 </head>
 
 <body>

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -11,10 +11,31 @@ if(css.styleSheet) { // IE does it this way
 }
 $('html head').get(0).appendChild(css)
 
+// http://unscriptable.com/index.php/2009/03/20/debouncing-javascript-methods/
+function debounce(func, threshold, execAsap) {
+  var timeout;
+  return function debounced() {
+    var obj = this, args = arguments;
+    var delayed = function() {
+      if (!execAsap) {
+        func.apply(obj, args);
+      }
+      timeout = null;
+    }
+    if (timeout) {
+      clearTimeout(timeout);
+    } else if (execAsap) {
+      func.apply(obj, args);
+    }
+
+    timeout = setTimeout(delayed, threshold || 100);
+  };
+}
+
 $(document).ready(function() {
   $('.single-checkbox-form').livequery(single_checkbox_form)
   // AJAXly call feedback?date=DATESTRING when date field changes, populate help box with result
-  $("#prediction_deadline_text").keyup(deadline_changed)
+  $("#prediction_deadline_text").keyup(debounce(deadline_changed, 500))
   $("#response_comment").keyup(response_preview)
   $("a[class~=facebox]").facebox()
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -35,7 +35,7 @@ function debounce(func, threshold, execAsap) {
 $(document).ready(function() {
   $('.single-checkbox-form').livequery(single_checkbox_form)
   // AJAXly call feedback?date=DATESTRING when date field changes, populate help box with result
-  $("#prediction_deadline_text").keyup(debounce(deadline_changed, 500))
+  $("#prediction_deadline_text").keyup(debounce(deadline_changed, 250))
   $("#response_comment").keyup(response_preview)
   $("a[class~=facebox]").facebox()
 

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -17,6 +17,11 @@ $(document).ready(function() {
   $("#prediction_deadline_text").keyup(deadline_changed)
   $("#response_comment").keyup(response_preview)
   $("a[class~=facebox]").facebox()
+
+  // The browser often fills out forms at load time
+  if($("#prediction_deadline_text").get(0)) {
+    deadline_changed.call($("#prediction_deadline_text").get(0));
+  }
 })
 
 // Focus first input field on page

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -87,7 +87,7 @@ function deadline_changed(event) {
     $.ajax({
       url: '/feedback',
       type: 'GET',
-      data: 'date=' + this.value,
+      data: 'date=' + encodeURIComponent(this.value),
       dataType: 'text',
       timeout: 5000,
       error: function() {
@@ -119,7 +119,7 @@ function response_preview(event) {
     $.ajax({
       url: '/responses/preview',
       type: 'GET',
-      data: 'response[comment]=' + this.value,
+      data: 'response[comment]=' + encodeURIComponent(this.value),
       dataType: 'text',
       timeout: 5000,
       success: function(text) {

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -36,12 +36,15 @@ $(document).ready(function() {
   $('.single-checkbox-form').livequery(single_checkbox_form)
   // AJAXly call feedback?date=DATESTRING when date field changes, populate help box with result
   $("#prediction_deadline_text").keyup(debounce(deadline_changed, 250))
-  $("#response_comment").keyup(response_preview)
+  $("#response_comment").keyup(debounce(response_preview, 250))
   $("a[class~=facebox]").facebox()
 
   // The browser often fills out forms at load time
   if($("#prediction_deadline_text").get(0)) {
     deadline_changed.call($("#prediction_deadline_text").get(0));
+  }
+  if($("#response_comment").get(0)) {
+    response_preview.call($("#response_comment").get(0));
   }
 })
 
@@ -98,7 +101,6 @@ function deadline_changed(event) {
       },
       success: function(text) {
         if(that.value != requestForValue) {
-          // Same explanation as for the `error` case.
           return;
         }
         $('#prediction_deadline_text_preview').text(text)
@@ -108,17 +110,22 @@ function deadline_changed(event) {
 }
 
 function response_preview(event) {
+  var that = this;
   if (this.value == '') {
     $('#response_comment_preview').text('')
   }
   else {
-    $.ajaxSync({
+    var requestForValue = this.value;
+    $.ajax({
       url: '/responses/preview',
       type: 'GET',
       data: 'response[comment]=' + this.value,
       dataType: 'text',
-      timeout: 1000,
+      timeout: 5000,
       success: function(text) {
+        if(that.value != requestForValue) {
+          return;
+        }
         $('#response_comment_preview').html(text)
       }
     });

--- a/public/javascripts/application.js
+++ b/public/javascripts/application.js
@@ -48,21 +48,33 @@ function single_checkbox_form() {
 }
 
 function deadline_changed(event) {
+  var that = this;
   if (this.value == '') {
     $('#prediction_deadline_preview').text('')
   }
   else {
+    var requestForValue = this.value;
     $('#prediction_deadline_text_preview').text('Waiting…')
-    $.ajaxSync({
+    $.ajax({
       url: '/feedback',
       type: 'GET',
       data: 'date=' + this.value,
       dataType: 'text',
-      timeout: 1000,
+      timeout: 5000,
       error: function() {
+        if(that.value != requestForValue) {
+          // Ignore the server response because the user changed the text
+          // box during the request.  That's okay though, because there's
+          // already a request for the new value.
+          return;
+        }
         $('#prediction_deadline_text_preview').text("I can't work out a time from that, sorry")
       },
       success: function(text) {
+        if(that.value != requestForValue) {
+          // Same explanation as for the `error` case.
+          return;
+        }
         $('#prediction_deadline_text_preview').text(text)
       }
     })

--- a/public/maintenance.html
+++ b/public/maintenance.html
@@ -4,7 +4,6 @@
 <head>
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
   <title>PredictionBook is currently undergoing some maintenance</title>
-	<link rel="stylesheet" type="text/css" href="/stylesheets/pbook.css">
 </head>
 
 <body>

--- a/public/styling/application.css
+++ b/public/styling/application.css
@@ -100,6 +100,9 @@ a:visited {
 h2 a:hover {
 	background-color: #ccc;
 }
+abbr {
+	border-bottom: 1px dotted #ccc;
+}
 
 /* Buttons
 -------------------------------------------------------------------------------------- */

--- a/public/styling/application.css
+++ b/public/styling/application.css
@@ -67,6 +67,7 @@ h1, h2 {
 h1 {
 	color: #363535;
 	font-size: 18px;
+	word-wrap: break-word;
 }
 h2 {
 	display: inline-block;
@@ -249,4 +250,8 @@ span.correct {
 span.wrong {
 	padding-right: 14px;
 	background: url(cross.png) bottom right no-repeat;
+}
+
+.break-word {
+	word-wrap: break-word;
 }

--- a/public/styling/application.css
+++ b/public/styling/application.css
@@ -75,6 +75,9 @@ h2 {
 	color: #fff;
 	font-weight: normal;
 	padding: 3px 10px;
+	border-radius: 4px;
+	-moz-border-radius: 4px;
+	-webkit-border-radius: 4px;
 }
 h3 {
 	font-size: 12px;

--- a/public/styling/application.css
+++ b/public/styling/application.css
@@ -41,13 +41,15 @@ div.wrapper {
 -------------------------------------------------------------------------------------- */
 .clear:after,
 form div.row:after {
-    clear: both;
-    content: ".";
-    display: block;
-    height: 0;
-    visibility: hidden;
+	clear: both;
+	content: ".";
+	display: block;
+	height: 0;
+	visibility: hidden;
 }
-a img {	border: none; }
+a img {
+	border: none;
+}
 
 
 /* General Typography
@@ -67,7 +69,7 @@ h1 {
 	font-size: 18px;
 }
 h2 {
-  display: inline-block;
+	display: inline-block;
 	font-size: 15px;
 	background-color: #221e1f;
 	color: #fff;
@@ -78,22 +80,22 @@ h3 {
 	font-size: 12px;
 }
 a {
-  text-decoration:none;
-  color: #00C;
+	text-decoration:none;
+	color: #00C;
 }
 a:hover {
-  background-color: #cee;
+	background-color: #cee;
 }
 a:visited {
-  color: #808;  
+	color: #808;
 }
-#content h2 a, h2 a:visited  {
-  color: white;
-  font-weight: normal;
-  text-decoration: underline;
+#content h2 a, h2 a:visited {
+	color: white;
+	font-weight: normal;
+	text-decoration: underline;
 }
 h2 a:hover {
-  background-color: #ccc;
+	background-color: #ccc;
 }
 
 /* Buttons
@@ -136,7 +138,7 @@ a.button {
 }
 
 #nav-menu li:hover {
-  background-color: #655271;
+	background-color: #655271;
 }
 
 ul#nav-menu {
@@ -169,18 +171,18 @@ ul#nav-menu li a {
 }
 
 #user-links li {
-  display: block;
-  float: left;
+	display: block;
+	float: left;
 }
 
 #user-links li::after {
-  content: '|';
-  margin: 0 10px;
+	content: '|';
+	margin: 0 10px;
 }
 
 #user-links li:last-child::after {
-  margin: 0;
-  content: '';
+	margin: 0;
+	content: '';
 }
 
 #header-main {
@@ -194,15 +196,15 @@ a#logo {
 	outline: none;
 }
 a#logo:hover {
-  background-color:inherit;
+	background-color:inherit;
 }
 a#logo img {
 	display: block;
 }
 #title {
-  text-align:right;
-  line-height: 75px;
-  margin-right: 3em;
+	text-align:right;
+	line-height: 75px;
+	margin-right: 3em;
 }
 #title h1 {
 }
@@ -220,20 +222,25 @@ a#logo img {
 }
 
 #notice, #error {
-  position: absolute;
-  margin: 0 30px 5px 30px;
-  top: 1em;
-  text-align: center;
-  width: 83%;
+	position: absolute;
+	margin: 0 30px 5px 30px;
+	top: 1em;
+	text-align: center;
+	width: 83%;
 }
-#error { color: #f22; font-weight: bold; }
-#notice { color: #2a2; }
+#error {
+	color: #f22;
+	font-weight: bold;
+}
+#notice {
+	color: #2a2;
+}
 
 span.correct {
-  padding-right: 17px;
-  background: url(tick.png) top right no-repeat;
+	padding-right: 17px;
+	background: url(tick.png) top right no-repeat;
 }
 span.wrong {
-  padding-right: 14px;
-  background: url(cross.png) bottom right no-repeat;
+	padding-right: 14px;
+	background: url(cross.png) bottom right no-repeat;
 }

--- a/public/styling/forms.css
+++ b/public/styling/forms.css
@@ -28,7 +28,7 @@ span.notice a {
 
 p.note {
   font-style: italic;
-  color: #999;
+  color: #777;
   width: 28em;
 }
 p.note em {

--- a/public/styling/forms.css
+++ b/public/styling/forms.css
@@ -52,7 +52,7 @@ form#new_prediction {
 	font-size: 11px;
 }
 form #prediction_description { width: 30em; height: 3.5em; }
-form #response_comment { height: 2.5em; }
+form #response_comment { height: 2.5em; width: 97%; }
 form input[type="text"],
 form input[type="password"],
 form textarea {

--- a/public/styling/home.css
+++ b/public/styling/home.css
@@ -54,7 +54,7 @@ body.home #new_prediction {
 }
 
 body.home #responses li {
-  margin: 0.75em;
+  margin: 0 0 0.75em 0.75em;
 }
 
 body.home #popular {

--- a/public/styling/predictions.css
+++ b/public/styling/predictions.css
@@ -19,9 +19,14 @@ ul#responses {
 div#responses {
   clear:both;
 }
-#responses ul {
+/* ul#responses is on the prediction pages;
+#responses ul is on the homepage. */
+ul#responses, #responses ul {
   padding-left: 0.5em;
   margin-left: 0.5em;
+}
+#responses li {
+  margin: 0 0 0.75em 0.75em;
 }
 #responses .change, #responses .change a {
   color: #777;

--- a/public/styling/predictions.css
+++ b/public/styling/predictions.css
@@ -1,7 +1,7 @@
 /* PREDICTIONS */
 
 h1 a.edit {
-  color: #999;
+  color: #777;
   font-size: x-small;
 }
 h1 a.edit:before { content: '[';}
@@ -24,7 +24,7 @@ div#responses {
   margin-left: 0.5em;
 }
 #responses .change, #responses .change a {
-  color: #999;
+  color: #777;
   font-style: italic;
 }
 #judgement .withdraw form { 

--- a/public/styling/predictions.css
+++ b/public/styling/predictions.css
@@ -92,6 +92,10 @@ p .responses {
   white-space: nowrap;
 }
 
+.confidence {
+  font-weight: bold;
+}
+
 .statistics table {
   width: 65%;
   margin-right: 1em;

--- a/public/styling/predictions.css
+++ b/public/styling/predictions.css
@@ -20,7 +20,7 @@ div#responses {
   clear:both;
 }
 /* ul#responses is on the prediction pages;
-#responses ul is on the homepage. */
+div#responses ul is on the homepage and happenstance. */
 ul#responses, #responses ul {
   padding-left: 0.5em;
   margin-left: 0.5em;

--- a/public/styling/predictions.css
+++ b/public/styling/predictions.css
@@ -31,6 +31,7 @@ ul#responses, #responses ul {
 #responses .change, #responses .change a {
   color: #777;
   font-style: italic;
+  word-wrap: break-word;
 }
 #judgement .withdraw form { 
   float: left; 
@@ -81,6 +82,9 @@ li.prediction.wrong {
 .prediction .description {
   padding: 0.2em 0 0 2em;
 }
+.title {
+  word-wrap: break-word;
+}
 h1.withdrawn, .prediction.withdrawn .title, span.withdrawn {
   text-decoration: line-through;
 }
@@ -95,6 +99,10 @@ span.notice, .judged .prediction .description .judgement,
 }
 p .responses {
   white-space: nowrap;
+}
+
+li.response, li.change, .comment {
+  word-wrap: break-word;
 }
 
 .confidence {

--- a/spec/controllers/predictions_controller_spec.rb
+++ b/spec/controllers/predictions_controller_spec.rb
@@ -57,8 +57,8 @@ describe PredictionsController do
         get :happenstance
         assigns[:unjudged].should == @mock_collection
       end
-      it 'should limit the predictions by 3' do
-        @mock_collection.should_receive(:limit).with(3).and_return(@mock_collection)
+      it 'should limit the predictions by 5' do
+        @mock_collection.should_receive(:limit).with(5).and_return(@mock_collection)
         get :happenstance
       end
     end 
@@ -71,8 +71,8 @@ describe PredictionsController do
         get :happenstance
         assigns[:judged].should == @mock_collection
       end
-      it 'should limit the predictions by 3' do
-        @mock_collection.should_receive(:limit).with(3).and_return(@mock_collection)
+      it 'should limit the predictions by 5' do
+        @mock_collection.should_receive(:limit).with(5).and_return(@mock_collection)
         get :happenstance
       end
     end 
@@ -85,8 +85,8 @@ describe PredictionsController do
         get :happenstance
         assigns[:responses].should == @mock_collection
       end
-      it 'should limit the comments by 6' do
-        @mock_collection.should_receive(:limit).with(6).and_return(@mock_collection)
+      it 'should limit the comments by 25' do
+        @mock_collection.should_receive(:limit).with(25).and_return(@mock_collection)
         get :happenstance
       end
     end
@@ -99,8 +99,8 @@ describe PredictionsController do
         get :happenstance
         assigns[:recent].should == @mock_collection
       end
-      it 'should limit the predictions by 3' do
-        @mock_collection.should_receive(:limit).with(3).and_return(@mock_collection)
+      it 'should limit the predictions by 5' do
+        @mock_collection.should_receive(:limit).with(5).and_return(@mock_collection)
         get :happenstance
       end
     end

--- a/spec/models/prediction_spec.rb
+++ b/spec/models/prediction_spec.rb
@@ -161,7 +161,7 @@ describe Prediction do
     describe 'popular predictions' do
     
       it "should have a finder for recent popular predictions" do
-        prediction1 = create_valid_prediction(:created_at => 2.weeks.ago, :deadline => 4.days.from_now)
+        prediction1 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 4.days.from_now)
         create_valid_response(:prediction => prediction1)
         prediction2 = create_valid_prediction(:created_at => 2.days.ago, :deadline => 2.days.from_now)
         prediction3 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 3.days.from_now)
@@ -172,22 +172,22 @@ describe Prediction do
       end
 
       it "excludes overdue predictions" do
-        prediction1 = create_valid_prediction(:created_at => 2.weeks.ago, :deadline => 1.day.ago)
-        prediction2 = create_valid_prediction(:created_at => 2.weeks.ago, :deadline => 1.day.from_now)
+        prediction1 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 1.day.ago)
+        prediction2 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 1.day.from_now)
         Prediction.popular.should == [prediction2]
       end
 
       it "excludes judged (known) predictions" do
-        prediction1 = create_valid_prediction(:created_at => 2.weeks.ago, :deadline => 1.day.from_now)
+        prediction1 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 1.day.from_now)
         create_valid_judgement(:prediction => prediction1, :outcome => false)
-        prediction2 = create_valid_prediction(:created_at => 2.weeks.ago, :deadline => 1.day.from_now)
+        prediction2 = create_valid_prediction(:created_at => 1.week.ago, :deadline => 1.day.from_now)
         Prediction.popular.should == [prediction2]
       end
       
-      it "excludes predictions made more than a month ago" do
-        create_valid_prediction(:created_at => 2.months.ago, :deadline => 1.day.from_now)
-        create_valid_prediction(:created_at => 3.months.ago, :deadline => 2.days.from_now)
-        create_valid_prediction(:created_at => 4.months.ago, :deadline => 3.days.from_now)
+      it "excludes predictions made more than 2 weeks ago" do
+        create_valid_prediction(:created_at => 3.weeks.ago, :deadline => 1.day.from_now)
+        create_valid_prediction(:created_at => 4.weeks.ago, :deadline => 2.days.from_now)
+        create_valid_prediction(:created_at => 5.weeks.ago, :deadline => 3.days.from_now)
         Prediction.popular.should be_empty
       end
       

--- a/spec/views/predictions/_events.html.erb_spec.rb
+++ b/spec/views/predictions/_events.html.erb_spec.rb
@@ -15,10 +15,10 @@ describe 'Prediction responses partial' do
     render_partial
     response.should have_tag('li', 2)
   end
-  it 'should show the responses relative_confidence' do
-    @wager.stub!(:relative_confidence).and_return(70)
+  it 'should show the responses confidence' do
+    @wager.stub!(:confidence).and_return(30)
     render_partial
-    response.should have_text(/70%/)
+    response.should have_text(/30%/)
   end
   it 'should not show nil relative_confidences' do
     @wager.should_not_receive(:relative_confidence)
@@ -34,11 +34,6 @@ describe 'Prediction responses partial' do
     @wager.stub!(:created_at).and_return(3.days.ago)
     render_partial
     response.should have_tag('span', '3 days ago')
-  end
-  it 'should show if response is in disagreement' do
-    @wager.stub!(:agree?).and_return(false)
-    render_partial
-    response.should have_text(/against/)
   end
   describe 'should include any supplied comments' do
     before(:each) do


### PR DESCRIPTION
There's a lot of stuff here, the highlights of which are:
- Removal of "NN% against" display logic, which frequently led users to estimate in the wrong direction.  I considered other solutions here, like highlighting "against" in red, but decided against them.
- Rephrasing of "How sure are you?" to "What's your estimate of this happening?" - I think this is clearer and simpler; see the commit for the justification.  I'm open to ideas here, of course.
- For durations of > 1 month, it now shows YYYY-MM-DD instead of a vague "N years ago"/"N months ago"
- "Judge this prediction" moved down, to hopefully avoid confusing new users
- JavaScript that previews deadline/comments fixed to avoid hammering the server and lying to users
- Several minor styling improvements (I hope)
- It now shows more happenstance on homepage and Happenstance
- Fixed https://github.com/tricycle/predictionbook/issues/4

Let me know if you need any changes un-done.

The tests pass and I manually tested every change in Firefox 6 and Chrome 13.  I also tested that the site basically still works in IE8.
