### PR TITLE
Add validation for dates really far in the future

### DIFF
--- a/app/models/prediction.rb
+++ b/app/models/prediction.rb
@@ -55,6 +55,7 @@ class Prediction < ActiveRecord::Base
   validates_presence_of :description, :message => 'What are you predicting?'
   validates_presence_of :initial_confidence, :message => 'How sure are you?', :on => :create
   validate :confidence_on_response, :on => :create
+  validate :maximum_deadline, :on => :create
   
   def after_validation
     errors.add(:deadline_text, errors.on(:deadline))
@@ -183,4 +184,11 @@ class Prediction < ActiveRecord::Base
       errors.add(:initial_confidence, @initial_response.errors.on(:confidence))
     end
   end
+  
+  def maximum_deadline
+    if !deadline.nil? && deadline.year > 9999
+      errors.add(:deadline, "Please consider creating a time capsule to record this prediction.")
+    end
+  end
+      
 end

--- a/spec/models/prediction_spec.rb
+++ b/spec/models/prediction_spec.rb
@@ -18,26 +18,37 @@ describe Prediction do
   end
   
   describe 'validations' do
-    before(:each) do
-      @prediction = Prediction.new
-      @prediction.valid?
+    describe 'with default values' do
+      before(:each) do
+        @prediction = Prediction.new
+        @prediction.valid?
+      end
+
+      it 'should pass on objects from modelfactory' do
+        valid_prediction.should be_valid
+        create_valid_prediction.should be_valid
+      end
+
+      it 'should require a creator' do
+        @prediction.should have(1).error_on(:creator)
+      end
+
+      it 'should require a deadline' do
+        @prediction.should have(1).error_on(:deadline)
+      end
+
+      it 'should require a description' do
+        @prediction.should have(1).error_on(:description)
+      end
     end
     
-    it 'should pass on objects from modelfactory' do
-      valid_prediction.should be_valid
-      create_valid_prediction.should be_valid
-    end
-    
-    it 'should require a creator' do
-      @prediction.should have(1).error_on(:creator)
-    end
-    
-    it 'should require a deadline' do
-      @prediction.should have(1).error_on(:deadline)
-    end
-    
-    it 'should require a description' do
-      @prediction.should have(1).error_on(:description)
+    describe 'with invalid values' do
+      it 'should not accept a deadline too far into the future to store' do
+        date = 300000.years.from_now
+        prediction = Prediction.new(:deadline => date)
+        prediction.valid?
+        prediction.should have(1).error_on(:deadline)
+      end
     end
   end
   


### PR DESCRIPTION
I broke (just my page) on predictionbook last week by creating a private prediction many many millennia in the future.

This fix should prevent that from happening again.
