### PR TITLE
Alert and page for overdue judgements

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,5 +1,5 @@
-class UsersController < ApplicationController
-  before_filter :lookup_user, :only => [:show, :update, :settings]
+ class UsersController < ApplicationController
+  before_filter :lookup_user, :only => [:show, :update, :settings, :due_for_judgement]
   before_filter :login_required, :only => [:settings, :update]
   before_filter :user_is_current_user, :only => [:settings, :update]
   
@@ -28,9 +28,16 @@ class UsersController < ApplicationController
   end
   
   def settings
-      @title = "Settings for #{current_user}"
+    @title = "Settings for #{current_user}"
   end
- 
+
+  def due_for_judgement
+    @title = "Predictions by #{@user} due for judgement"
+    @predictions = @user.predictions
+    @predictions = @predictions.not_private unless current_user == @user
+    @predictions = @predictions.select { |x| x.due_for_judgement? }
+  end
+
   def create
     logout_keeping_session!
     @user = User.new(params[:user])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 require 'digest/sha1'
 
 class User < ActiveRecord::Base
@@ -63,6 +64,10 @@ class User < ActiveRecord::Base
   
   def has_email?
     !email.blank?
+  end
+
+  def has_overdue_judgements?
+    !!predictions.index { |x| x.due_for_judgement?}
   end
 
   def authorized_for(prediction)

--- a/app/views/layouts/_messages.html.erb
+++ b/app/views/layouts/_messages.html.erb
@@ -4,3 +4,7 @@
 <% if flash[:notice] %>
   <div id="notice"><%=flash[:notice] %></div>
 <% end %>
+<% if current_user && current_user.has_overdue_judgements? %>
+  <div id="overdue">You have one or more predictions with overdue judgements.
+  <%= link_to 'Judge them!', due_for_judgement_user_path(current_user) %></div>
+<% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -78,7 +78,7 @@
       <li><a href="#">Links</a></li> %>
 		</ul>
 	<ul class="right-links">
-		<span class="copyright">PredictionBook © 2008-2011</span>
+		<span class="copyright">PredictionBook © 2008-2013</span>
 	</ul>
 
 

--- a/app/views/users/due_for_judgement.html.erb
+++ b/app/views/users/due_for_judgement.html.erb
@@ -1,0 +1,6 @@
+<div id="predictions">
+  <h2>Overdue predictions by <%= show_user(@user) %></h2>
+  <ul>
+  <%= render :partial => @predictions %>
+  </ul>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,7 +11,9 @@ ActionController::Routing::Routes.draw do |map|
     users.signup '/signup', :action => 'new'
   end
   
-  map.resources :users, :member => {:settings => :get}, :has_many => :deadline_notifications
+  map.resources :users,
+  :member => {:settings => :get, :due_for_judgement => :get },
+  :has_many => :deadline_notifications
 
   map.resources :deadline_notifications
   map.resources :response_notifications

--- a/public/styling/application.css
+++ b/public/styling/application.css
@@ -228,7 +228,7 @@ a#logo img {
 	font-weight: bold;
 }
 
-#notice, #error {
+#notice, #error, #overdue {
 	position: absolute;
 	margin: 0 30px 5px 30px;
 	top: 1em;


### PR DESCRIPTION
I've added a "due_for_judgement" page so that users can view all of their predictions which have passed the deadline but still have not been judged. Users can go to http://predictionbook.com/users/username/due_for_judgement to view them. If there are any predictions due for judgement, an alert message is displayed on every page with a link to the url above.

I also changed to copyright notice at the bottom from "2008-2011" to "2008-2013."

This is my first time using Rails so let me know if I've done anything in a non-railsy way.
